### PR TITLE
Add volume to allow for host data to be used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN cd $SUMO_HOME && ./configure && make install
 # Ensure the installation works. If this call fails, the whole build will fail.
 RUN sumo
 
+# Add volume to allow for host data to be used
+RUN mkdir /data
+VOLUME /data
+
 ENTRYPOINT ["sumo"]
 
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get update && apt-get install -qq \
     make \
     libxerces-c3.1 \
     libxerces-c3-dev \
-    python
+    python \
+    libproj-dev \
+    proj-bin
 
 # Download and extract source code
 RUN wget http://downloads.sourceforge.net/project/sumo/sumo/version%20$SUMO_VERSION/sumo-src-$SUMO_VERSION.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN sumo
 RUN mkdir /data
 VOLUME /data
 
+# Expose a port so that SUMO can be started with --remote-port 1234 to be controlled from outside Docker
+EXPOSE 1234
+
 ENTRYPOINT ["sumo"]
 
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM debian:wheezy
+FROM maven:3
 
-MAINTAINER Oliver Lade <oliver@similitude.org>
-# See http://sumo.dlr.de/wiki/Installing/Linux_Build
-
-ENV SUMO_VERSION 0.21.0
+ENV SUMO_VERSION 0.25.0
 ENV SUMO_SRC sumo-src-$SUMO_VERSION
 ENV SUMO_HOME /opt/sumo
 
@@ -16,7 +13,7 @@ RUN apt-get update && apt-get install -qq \
     libxerces-c3-dev \
     python
 
-# Download and extract the source code.
+# Download and extract source code
 RUN wget http://downloads.sourceforge.net/project/sumo/sumo/version%20$SUMO_VERSION/sumo-src-$SUMO_VERSION.tar.gz
 RUN tar xzf sumo-src-$SUMO_VERSION.tar.gz && \
     mv sumo-$SUMO_VERSION $SUMO_HOME && \
@@ -28,10 +25,17 @@ RUN cd $SUMO_HOME && ./configure && make install
 # Ensure the installation works. If this call fails, the whole build will fail.
 RUN sumo
 
+# Download and compile traci4j library
+RUN apt-get install -qq -y ssh-client git
+RUN mkdir -p /opt/traci4j 
+WORKDIR /opt/traci4j
+RUN git clone https://github.com/egueli/TraCI4J.git /opt/traci4j && mvn package -Dmaven.test.skip=true
+
 # Add volume to allow for host data to be used
 RUN mkdir /data
 VOLUME /data
 
+EXPOSE 1234
 ENTRYPOINT ["sumo"]
 
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run with Docker
 docker run --rm -t -i -v /some/local/path/to/your/data:/data farberg/sumo-docker
 ```
 
-(This uses an automated build on Dockerhub: https://github.com/pfisterer/sumo-docker).
+(This uses an automated build on Dockerhub: https://hub.docker.com/r/farberg/sumo-docker/).
 
 See also:
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ A Docker base image for the SUMO traffic simulation package.
 
 Run with Docker
 -------------
+This uses an automated build on Dockerhub: https://hub.docker.com/r/farberg/sumo-docker/ so you don't have to build the image for yourself.
+
 ```
 docker run --rm -t -i -p 1234:1234 -v /some/local/path/to/your/data:/data farberg/sumo-docker
 ```
 
-(This uses an automated build on Dockerhub: https://hub.docker.com/r/farberg/sumo-docker/).
+Example of using Sumo with [Traci4J](https://github.com/egueli/TraCI4J):
+```
+docker run -t -i --rm -p 1234:1234 -v /some/local/path/to/your/data:/data farberg/sumo-docker -c /data/cologne.sumocfg --remote-port 1234 -v
+```
+
 
 See also:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ A Docker base image for the SUMO traffic simulation package.
 > microscopic and continuous road traffic simulation package designed to handle
 > large road networks.
 
+Run with Docker
+-------------
+docker run --rm -t -i -v /some/local/path/to/your/data:/data farberg/sumo-docker
+
+(This uses an automated build on Dockerhub: https://github.com/pfisterer/sumo-docker).
+
 See also:
 
 * [SUMO Wiki](http://sumo.dlr.de/wiki/Main_Page)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Docker base image for the SUMO traffic simulation package.
 Run with Docker
 -------------
 ```
-docker run --rm -t -i -v /some/local/path/to/your/data:/data farberg/sumo-docker
+docker run --rm -t -i -p 1234:1234 -v /some/local/path/to/your/data:/data farberg/sumo-docker
 ```
 
 (This uses an automated build on Dockerhub: https://hub.docker.com/r/farberg/sumo-docker/).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A Docker base image for the SUMO traffic simulation package.
 
 Run with Docker
 -------------
+```
 docker run --rm -t -i -v /some/local/path/to/your/data:/data farberg/sumo-docker
+```
 
 (This uses an automated build on Dockerhub: https://github.com/pfisterer/sumo-docker).
 


### PR DESCRIPTION
Adds support for Docker volumes (https://docs.docker.com/engine/userguide/containers/dockervolumes/). This allows to use data from the host computer or another container to be used as input for sumo.
