### PR TITLE
Update sumo to 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3
 
-ENV SUMO_VERSION 0.25.0
+ENV SUMO_VERSION 1.3.1
 ENV SUMO_SRC sumo-src-$SUMO_VERSION
 ENV SUMO_HOME /opt/sumo
 
@@ -8,19 +8,26 @@ ENV SUMO_HOME /opt/sumo
 RUN apt-get update && apt-get install -qq \
     wget \
     g++ \
-    make \
+    cmake \
     libxerces-c3.1 \
-    libxerces-c3-dev \
+    libxerces-c-dev \
+    libgdal-dev \
+    libproj-dev \
+    libfox-1.6-dev\
+    libgl2ps-dev\ 
+    swig\
     python
 
 # Download and extract source code
-RUN wget http://downloads.sourceforge.net/project/sumo/sumo/version%20$SUMO_VERSION/sumo-src-$SUMO_VERSION.tar.gz
+RUN wget https://sumo.dlr.de/releases/$SUMO_VERSION/sumo-src-$SUMO_VERSION.tar.gz
 RUN tar xzf sumo-src-$SUMO_VERSION.tar.gz && \
     mv sumo-$SUMO_VERSION $SUMO_HOME && \
     rm sumo-src-$SUMO_VERSION.tar.gz
 
 # Configure and build from source.
-RUN cd $SUMO_HOME && ./configure && make install
+RUN cd $SUMO_HOME && mkdir build/cmake-build && \ 
+    cd build/cmake-build && cmake ../.. && make -j $(nproc) && \
+    make install
 
 # Ensure the installation works. If this call fails, the whole build will fail.
 RUN sumo
@@ -41,4 +48,3 @@ EXPOSE 1234
 ENTRYPOINT ["sumo"]
 
 CMD ["--help"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN sumo
 RUN apt-get install -qq -y ssh-client git
 RUN mkdir -p /opt/traci4j 
 WORKDIR /opt/traci4j
-RUN git clone https://github.com/egueli/TraCI4J.git /opt/traci4j && mvn package -Dmaven.test.skip=true
+RUN git clone https://github.com/egueli/TraCI4J.git /opt/traci4j
+RUN mvn package -f pom.xml -Dmaven.test.skip=true -Dmaven.compiler.source=1.6 -Dmaven.compiler.target=1.6
 
 # Add volume to allow for host data to be used
 RUN mkdir /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ RUN apt-get update && apt-get install -qq \
     make \
     libxerces-c3.1 \
     libxerces-c3-dev \
-    python \
-    libproj-dev \
-    proj-bin
+    python
 
 # Download and extract source code
 RUN wget http://downloads.sourceforge.net/project/sumo/sumo/version%20$SUMO_VERSION/sumo-src-$SUMO_VERSION.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
 SUMO Docker Base Image
 ======================
 
-A Docker base image for the SUMO traffic simulation package.
-
-> "Simulation of Urban MObility" (SUMO) is an open source, highly portable,
-> microscopic and continuous road traffic simulation package designed to handle
-> large road networks.
+A Docker base image for the [SUMO](http://sumo.dlr.de/wiki/Main_Page) traffic simulation package. SUMO (Simulation of Urban MObility) is an open source, highly portable, microscopic and continuous road traffic simulation package designed to handle large road networks.
 
 Run with Docker
 -------------
 This uses an automated build on Dockerhub: https://hub.docker.com/r/farberg/sumo-docker/ so you don't have to build the image for yourself.
 
+This Dockerfile uses Docker's concept of [volumes](https://docs.docker.com/v1.10/engine/userguide/containers/dockervolumes/) where you make one or more folders on your host computer available inside the docker container. The paths of these volumes are specificed in the [Dockerfile](Dockerfile). In this case, you can make a folder on your host computer available as ```/data``` in the Docker container. 
+
+For example, if you have your SUMO files stored in the folder ```/some/local/path/to/your/data``` on your host computer, you can "mount" this folder as follows: ``` -v /some/local/path/to/your/data:/data```. When passing command line arguments to SUMO, use ```/data``` instead of the real folder's name on your computer.
+
+This command illustrates this:
 ```
 docker run --rm -t -i -p 1234:1234 -v /some/local/path/to/your/data:/data farberg/sumo-docker
 ```
 
-Example of using Sumo with [Traci4J](https://github.com/egueli/TraCI4J):
+Control SUMO via TraCi
+-------------
+
+Use the following command if you want to control SUMO using the [Traffic Control Interface ](TraCI). This exposes SUMO's features on port 1234 via TCP/IP:
 ```
 docker run -t -i --rm -p 1234:1234 -v /some/local/path/to/your/data:/data farberg/sumo-docker -c /data/cologne.sumocfg --remote-port 1234 -v
 ```
 
+Java API for TraCI
+-------------
 
-See also:
+A Java API for TraCI is available [here](https://github.com/egueli/TraCI4J). 
 
-* [SUMO Wiki](http://sumo.dlr.de/wiki/Main_Page)
-* [SUMO on SourceForge](http://sourceforge.net/projects/sumo/)
-* [SUMO Simmer package](https://github.com/similitude/sumo-simmer)
-* More information about [Docker](https://www.docker.com/)
+An example application that uses TraCI4J is available [here](https://github.com/pfisterer/sumo-traci-demo).
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ Control SUMO via TraCi
 
 Use the following command if you want to control SUMO using the [Traffic Control Interface ](TraCI). This exposes SUMO's features on port 1234 via TCP/IP:
 ```
-docker run -t -i --rm -p 1234:1234 -v /some/local/path/to/your/data:/data farberg/sumo-docker -c /data/cologne.sumocfg --remote-port 1234 -v
+docker run -t -i --rm -p 1234:1234 \
+	-v /some/local/path/to/your/data:/data \
+	farberg/sumo-docker \
+	-c /data/cologne.sumocfg \
+	--remote-port 1234 \
+	-v
 ```
+(remove all \ in the previous example if you use a single line instead of multiple lines)
 
 Java API for TraCI
 -------------


### PR DESCRIPTION
## changes

- Uses pfisterer fork as a base
- Update sumo version
- change make process to use cmake as per build instructions https://sumo.dlr.de/docs/Installing/Linux_Build.html
- force maven to use a supported source and target version (egueli/TraCI4J#33)

## testing
build the image

`docker build -t sumo_image .`
check it worked by getting the version of sumo in the docker

```bash
docker run -ti sumo_image --version
Eclipse SUMO Version 1.3.1
 Build features: Linux-4.15.0-66-generic x86_64 GNU 6.3.0 Release Proj GUI GDAL GL2PS SWIG
 Copyright (C) 2001-2019 German Aerospace Center (DLR) and others; https://sumo.dlr.de

Eclipse SUMO Version 1.3.1 is part of SUMO.
This program and the accompanying materials
are made available under the terms of the Eclipse Public License v2.0
which accompanies this distribution, and is available at
http://www.eclipse.org/legal/epl-v20.html
SPDX-License-Identifier: EPL-2.0
```

there should be sumo 1.3.1 in container